### PR TITLE
bug: fix bug in params initialization

### DIFF
--- a/pypress/keras/initializers.py
+++ b/pypress/keras/initializers.py
@@ -155,7 +155,7 @@ class PredictiveStateMeansInitializer(tf.keras.initializers.Initializer):
 
 
 def _get_predictive_state_params_init(
-    init_values: Union[Sequence[Union[float, np.ndarray]], np.ndarray],
+    init_values: np.ndarray,
     n_states: int,
     n_params_per_state: int,
     activations: Sequence[str],
@@ -166,11 +166,10 @@ def _get_predictive_state_params_init(
     activation functions for each parameter.
 
     Args:
-        init_values: Either:
-            - Sequence of initial values (one per parameter) on original scale.
-              Each element can be a scalar or 1D array. Must have length n_params_per_state.
-            - np.ndarray of shape (n_params_per_state, n_states) with state-specific
-              values for each parameter (e.g., from initialize_from_y with return_params=True).
+        init_values: np.ndarray of shape (n_params_per_state, n_states) with
+            state-specific values for each parameter. Each row represents one
+            parameter, columns are states. Use initialize_from_y with
+            return_params=True to generate this from data.
         n_states: Number of predictive states.
         n_params_per_state: Number of parameters per state.
         activations: Sequence of activation function names (one per parameter).
@@ -179,25 +178,21 @@ def _get_predictive_state_params_init(
         TensorFlow variable with initial logits of shape (n_states, n_params_per_state).
 
     Raises:
-        ValueError: If init_values shape doesn't match expectations or if
-            activations are not supported.
+        ValueError: If init_values shape doesn't match (n_params_per_state, n_states).
     """
-    # Check if init_values is a 2D array with shape (n_params_per_state, n_states)
-    if isinstance(init_values, np.ndarray) and len(init_values.shape) == 2:
-        if init_values.shape != (n_params_per_state, n_states):
-            raise ValueError(
-                f"init_values as 2D array must have shape ({n_params_per_state}, {n_states}), "
-                f"got {init_values.shape}"
-            )
-        # Convert to list of 1D arrays, one per parameter
-        init_values_list = [init_values[i, :] for i in range(n_params_per_state)]
-    else:
-        # Already a sequence/list
-        init_values_list = init_values
+    # Convert to numpy array if needed
+    init_values = np.asarray(init_values)
 
-    if len(init_values_list) != n_params_per_state:
+    # Check shape
+    if len(init_values.shape) != 2:
         raise ValueError(
-            f"init_values must have length {n_params_per_state}, got {len(init_values_list)}"
+            f"init_values must be a 2D array, got shape {init_values.shape}"
+        )
+
+    if init_values.shape != (n_params_per_state, n_states):
+        raise ValueError(
+            f"init_values must have shape ({n_params_per_state}, {n_states}), "
+            f"got {init_values.shape}"
         )
 
     if len(activations) != n_params_per_state:
@@ -207,38 +202,12 @@ def _get_predictive_state_params_init(
 
     # Build initialized values for each parameter
     param_logits = []
-    for i, (init_val, activation) in enumerate(zip(init_values_list, activations)):
+    for i, activation in enumerate(activations):
         # Get inverse activation for this parameter
         inverse_fn = get_inverse_activation(activation)
 
-        # Build value on original scale (n_states,)
-        if isinstance(init_val, (float, int)):
-            # Scalar: broadcast to all states
-            val = np.ones(n_states) * init_val
-        elif isinstance(init_val, np.ndarray):
-            if len(init_val.shape) == 0:  # scalar array
-                val = np.ones(n_states) * float(init_val)
-            elif len(init_val.shape) == 1:
-                if init_val.shape[0] == 1:
-                    # Single element array: broadcast to all states
-                    val = np.ones(n_states) * init_val[0]
-                elif init_val.shape[0] == n_states:
-                    # State-specific values: one value per state
-                    val = init_val
-                else:
-                    raise ValueError(
-                        f"init_values[{i}] must have length 1 or {n_states}, "
-                        f"got shape {init_val.shape}"
-                    )
-            else:
-                raise ValueError(
-                    f"init_values[{i}] must be scalar or 1D array, "
-                    f"got shape {init_val.shape}"
-                )
-        else:
-            raise ValueError(
-                f"init_values[{i}] must be float or np.ndarray, got {type(init_val)}"
-            )
+        # Get state-specific values for this parameter (row i)
+        val = init_values[i, :]  # Shape: (n_states,)
 
         # Convert to logits
         val_logits = inverse_fn(tf.constant(val, dtype=tf.float32))

--- a/pypress/tests/test_initializers.py
+++ b/pypress/tests/test_initializers.py
@@ -324,14 +324,22 @@ def test_predictive_state_means_layer_with_sigmoid_init():
 
 def test_predictive_state_params_initializer_gaussian():
     """Test PredictiveStateParamsInitializer with Gaussian (mean, std) parameters."""
-    # Gaussian distribution with mean=0.0, std=1.0
+    # Gaussian distribution with mean=0.0, std=1.0 (broadcast to all states)
     init_mean = 0.0
     init_std = 1.0
     n_states = 4
     activations = ["linear", "softplus"]  # mean: linear, std: softplus
 
+    # Create 2D array with shape (n_params_per_state, n_states)
+    init_values = np.array(
+        [
+            [init_mean] * n_states,  # Row 0: means for all states
+            [init_std] * n_states,  # Row 1: stds for all states
+        ]
+    )
+
     initializer = PredictiveStateParamsInitializer(
-        init_values=[init_mean, init_std], n_states=n_states, activations=activations
+        init_values=init_values, n_states=n_states, activations=activations
     )
 
     shape = (n_states, 2)  # 2 params per state
@@ -361,15 +369,24 @@ def test_predictive_state_params_layer_with_gaussian_init():
     """Test PredictiveStateParams layer with Gaussian (mean, std) initialization."""
     from pypress.keras.layers import PredictiveStateParams
 
-    # Initialize Gaussian parameters: mean=0.5, std=2.0
+    # Initialize Gaussian parameters: mean=0.5, std=2.0 (broadcast to all states)
     init_mean = 0.5
     init_std = 2.0
     n_states = 3
+    n_params_per_state = 2
+
+    # Create 2D array with shape (n_params_per_state, n_states)
+    init_values = np.array(
+        [
+            [init_mean] * n_states,  # Row 0: means for all states
+            [init_std] * n_states,  # Row 1: stds for all states
+        ]
+    )
 
     layer = PredictiveStateParams(
-        n_params_per_state=2,
+        n_params_per_state=n_params_per_state,
         activations=["linear", "softplus"],
-        init_values=[init_mean, init_std],
+        init_values=init_values,
         flatten_output=False,
     )
 
@@ -424,10 +441,18 @@ def test_predictive_state_params_initializer_state_specific_gaussian():
     )
 
     # Create layer (init_values doesn't matter since we'll overwrite weights)
+    # Use dummy init_values with shape (n_params_per_state, n_states)
+    dummy_init_values = np.array(
+        [
+            [0.0] * n_states,  # Row 0: means
+            [1.0] * n_states,  # Row 1: stds
+        ]
+    )
+
     layer = PredictiveStateParams(
         n_params_per_state=n_params_per_state,
         activations=activations,
-        init_values=[0.0, 1.0],  # Will be overwritten
+        init_values=dummy_init_values,  # Will be overwritten
         flatten_output=False,
     )
 

--- a/pypress/tests/test_layers.py
+++ b/pypress/tests/test_layers.py
@@ -222,7 +222,13 @@ class TestPredictiveStateParams:
 
         # Custom initialization - values on original scale
         # With linear activation, these become the logits directly
-        custom_values = [1.0, 2.0]  # One value per parameter
+        # Create 2D array with shape (n_params_per_state, n_states)
+        custom_values = np.array(
+            [
+                [1.0, 1.0],  # Row 0: param 0 for both states
+                [2.0, 2.0],  # Row 1: param 1 for both states
+            ]
+        )
 
         layer = layers.PredictiveStateParams(
             n_params_per_state=n_params,

--- a/pypress/tests/test_utils.py
+++ b/pypress/tests/test_utils.py
@@ -221,13 +221,16 @@ def test_initialize_from_y_params():
     y = np.random.randn(200) + 10  # Mean 10, std 1
 
     n_states = 3
+    n_params_per_state = 2
     init_values = utils.initialize_from_y(y, n_states=n_states, return_params=True)
 
-    # Should return tuple of (means_array, stds_array)
-    assert isinstance(init_values, tuple)
-    assert len(init_values) == 2
+    # Should return array of shape (n_params_per_state, n_states)
+    assert isinstance(init_values, np.ndarray)
+    assert init_values.shape == (n_params_per_state, n_states)
 
-    means_array, stds_array = init_values
+    # Row 0: means, Row 1: stds
+    means_array = init_values[0, :]
+    stds_array = init_values[1, :]
 
     # Each should be shape (n_states,)
     assert means_array.shape == (n_states,)

--- a/pypress/utils.py
+++ b/pypress/utils.py
@@ -126,9 +126,9 @@ def initialize_from_y(
             np.ndarray of shape (units, n_states) with state-conditional means,
             suitable for init_values in PredictiveStateMeans.
         If return_params=True:
-            Tuple of (means_array, stds_array) where each is shape (n_states,),
-            suitable for init_values in PredictiveStateParams with
-            activations=["linear", "softplus"].
+            np.ndarray of shape (n_params_per_state, n_states) where
+            row 0 is means and row 1 is stds, suitable for init_values in
+            PredictiveStateParams with activations=["linear", "softplus"].
 
     Example:
         >>> # For PredictiveStateMeans
@@ -177,9 +177,10 @@ def initialize_from_y(
     cluster_stds = gmm.covariances_  # Shape: (n_states,)
 
     if return_params:
-        # Return format for PredictiveStateParams: (means_array, stds_array)
-        # Each array has shape (n_states,) with state-specific parameters
-        return (cluster_means, cluster_stds)
+        # Return format for PredictiveStateParams: (n_params_per_state, n_states) array
+        # Row 0: means, Row 1: stds
+        init_values = np.vstack([cluster_means, cluster_stds])  # Shape: (2, n_states)
+        return init_values
     else:
         # Return format for PredictiveStateMeans: (units, n_states) array
         # Each row represents one output dimension, columns are states

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pypress"
-version = "0.1.1"
+version = "0.1.2"
 description = "Predictive State Smoothing (PRESS) in Python (keras)"
 authors = [
     {name = "Georg M. Goerg",email = "im@gmge.org"}


### PR DESCRIPTION
## Simplify `PredictiveStateParams` initialization API

Refactors `_get_predictive_state_params_init` to accept only 2D arrays of shape `(n_params_per_state, n_states)`, removing support for confusing list/tuple formats.

**Changes:**
- `initialize_from_y(return_params=True)` now returns single `np.ndarray` of shape `(2, n_states)` instead of tuple `(means, stds)`
- `_get_predictive_state_params_init` now requires 2D array format only
- Removes error-prone `Sequence[Union[float, np.ndarray]]` type that allowed mismatched array lengths

**Before:**
```python
init_values = initialize_from_y(y, 5, return_params=True)
# Returns: (array([...]), array([...]))  # Tuple

# Multiple confusing formats accepted
layer = PredictiveStateParams(init_values=[0.0, 1.0], ...)  # List
layer = PredictiveStateParams(init_values=(means, stds), ...)  # Tuple
```

After:
```
init_values = initialize_from_y(y, 5, return_params=True)
# Returns: array([[...], [...]])  # Shape: (2, 5)

# Single clean format
layer = PredictiveStateParams(init_values=init_values, ...)